### PR TITLE
Feature/37/edit forgot password page

### DIFF
--- a/src/pages/ForgetPassword/ForgetPassword.jsx
+++ b/src/pages/ForgetPassword/ForgetPassword.jsx
@@ -81,7 +81,7 @@ export default function ForgetPassword() {
                       <div className={styles.success}>
                         <img className={styles.success__icon} src={logoEmailSent} alt="email-sent-icon" />
                         <h3 className={styles.success__title}>Check you email</h3>
-                        <br />
+
                         <span className={styles.success__text}>
                           A link to reset your password has been sent to{' '}
                           <strong>{emailDisplay.current}</strong>

--- a/src/pages/ForgetPassword/ForgetPassword.jsx
+++ b/src/pages/ForgetPassword/ForgetPassword.jsx
@@ -67,34 +67,34 @@ export default function ForgetPassword() {
   return (
     <Container className={styles.page}>
       <Header />
-      <Container className={styles.page__window}>
+      <Container className={styles['page-window']}>
         <div>
           <Row>
             <Col className="d-flex px-0 justify-content-center align-items-center">
               <div>
                 <Form
-                  className={`content-layout ${styles.page__wrapper}`}
+                  className={`content-layout ${styles['page-wrapper']}`}
                   onSubmit={handleForgotPassword}>
-                  <h2 className={styles.page__title}>Forgot Password</h2>
+                  <></>
+                  <h2 className={styles['page-title']}>Forgot Password</h2>
                   {success && sentEmail ? (
-                    <>
-                      <div className={styles.success}>
-                        <img className={styles.success__icon} src={logoEmailSent} alt="email-sent-icon" />
-                        <h3 className={styles.success__title}>Check you email</h3>
+                    <section className={styles.success}>
+                      <img className={styles['success-icon']} src={logoEmailSent} alt="email-sent-icon" />
+                      <h3 className={styles['success-heading']}>Check you email</h3>
 
-                        <span className={styles.success__text}>
-                          A link to reset your password has been sent to{' '}
-                          <strong>{emailDisplay.current}</strong>
-                        </span>
-                      </div>
-                    </>
+                      <span className={styles['success-text']}>
+                        A link to reset your password has been sent to{' '}
+                        <strong>{emailDisplay.current}</strong>
+                      </span>
+                    </section>
+
                   ) : !success && errMsg ? (
                     <MessageBar variant="error">{errMsg}</MessageBar>
                   ) : null}
 
                   {success && sentEmail ? null : (
-                    <>
-                      <p className={styles.page__text}>
+                    <section className={styles.reset}>
+                      <p className={styles['reset-text']}>
                         Please enter your account email address and we will send instructions to
                         reset your password.
                       </p>
@@ -103,18 +103,18 @@ export default function ForgetPassword() {
                         value={email}
                         required
                         label="Email"
-                        className={styles.input__email}
+                        className={styles['reset-input']}
                       />
                       <CustomButton
-                        styles={`primary-light ${styles.page__customButton}`}
+                        styles={`primary-light ${styles['reset-custom-button']}`}
                         type="submit"
                         size="lg"
                         variant="light">
                         Next
                       </CustomButton>
-                    </>
+                    </section>
                   )}
-                  <NavLink to="/signin" className={styles.page__link}>
+                  <NavLink to="/signin" className={styles['page-link']}>
                     Back to Log in
                   </NavLink>
                 </Form>

--- a/src/pages/ForgetPassword/ForgetPassword.jsx
+++ b/src/pages/ForgetPassword/ForgetPassword.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Container, Form, Row, Col } from 'react-bootstrap';
-import { Link, NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 
 import { forgetPassword } from '@api';
 
@@ -44,56 +44,49 @@ export default function ForgetPassword() {
     }
   };
 
-  const handleResendEmail = async () => {
-    setSuccess(false);
-    setSentEmail(false);
-    setErrMsg('');
-    try {
-      const res = await forgetPassword(email);
-      if (res.status === 200) {
-        setEmail('');
-        setSentEmail(true);
-        setSuccess(true);
-      } else {
-        setErrMsg(res.message);
-      }
-    } catch (err) {
-      //eslint-disable-next-line
-      console.error(err);
-      setErrMsg('An error occurred while resending the email. Please try again later.');
-    }
-  };
+  // const handleResendEmail = async () => {
+  //   setSuccess(false);
+  //   setSentEmail(false);
+  //   setErrMsg('');
+  //   try {
+  //     const res = await forgetPassword(email);
+  //     if (res.status === 200) {
+  //       setEmail('');
+  //       setSentEmail(true);
+  //       setSuccess(true);
+  //     } else {
+  //       setErrMsg(res.message);
+  //     }
+  //   } catch (err) {
+  //     //eslint-disable-next-line
+  //     console.error(err);
+  //     setErrMsg('An error occurred while resending the email. Please try again later.');
+  //   }
+  // };
 
   return (
     <Container className={styles.page}>
-      <Header/>
+      <Header />
       <Container className={styles.page__window}>
         <div>
           <Row>
-            <Col className="d-flex justify-content-center align-items-center">
+            <Col className="d-flex px-0 justify-content-center align-items-center">
               <div>
                 <Form
                   className={`content-layout ${styles.page__wrapper}`}
                   onSubmit={handleForgotPassword}>
-                  <h1 className={styles.page__title}>Forgot Password</h1>
+                  <h2 className={styles.page__title}>Forgot Password</h2>
                   {success && sentEmail ? (
                     <>
                       <div className={styles.success}>
-                        <img src={logoEmailSent} alt="email-sent-logo" />
-                        <span>Check you email</span>
+                        <img className={styles.success__icon} src={logoEmailSent} alt="email-sent-icon" />
+                        <h3 className={styles.success__title}>Check you email</h3>
                         <br />
-                        <span>
+                        <span className={styles.success__text}>
                           A link to reset your password has been sent to{' '}
                           <strong>{emailDisplay.current}</strong>
                         </span>
                       </div>
-
-                      <Link
-                        type="button"
-                        className={`btn checkbox mb-3 ${styles.resend__email}`}
-                        onClick={() => handleResendEmail()}>
-                        Resend Email
-                      </Link>
                     </>
                   ) : !success && errMsg ? (
                     <MessageBar variant="error">{errMsg}</MessageBar>
@@ -101,7 +94,7 @@ export default function ForgetPassword() {
 
                   {success && sentEmail ? null : (
                     <>
-                      <p className={styles.text}>
+                      <p className={styles.page__text}>
                         Please enter your account email address and we will send instructions to
                         reset your password.
                       </p>
@@ -113,7 +106,7 @@ export default function ForgetPassword() {
                         className={styles.input__email}
                       />
                       <CustomButton
-                        styles={`primary-light ${styles.customButton}`}
+                        styles={`primary-light ${styles.page__customButton}`}
                         type="submit"
                         size="lg"
                         variant="light">
@@ -121,7 +114,7 @@ export default function ForgetPassword() {
                       </CustomButton>
                     </>
                   )}
-                  <NavLink to="/signin" className={styles.forget__password}>
+                  <NavLink to="/signin" className={styles.page__link}>
                     Back to Log in
                   </NavLink>
                 </Form>

--- a/src/pages/ForgetPassword/ForgetPassword.jsx
+++ b/src/pages/ForgetPassword/ForgetPassword.jsx
@@ -44,26 +44,6 @@ export default function ForgetPassword() {
     }
   };
 
-  // const handleResendEmail = async () => {
-  //   setSuccess(false);
-  //   setSentEmail(false);
-  //   setErrMsg('');
-  //   try {
-  //     const res = await forgetPassword(email);
-  //     if (res.status === 200) {
-  //       setEmail('');
-  //       setSentEmail(true);
-  //       setSuccess(true);
-  //     } else {
-  //       setErrMsg(res.message);
-  //     }
-  //   } catch (err) {
-  //     //eslint-disable-next-line
-  //     console.error(err);
-  //     setErrMsg('An error occurred while resending the email. Please try again later.');
-  //   }
-  // };
-
   return (
     <Container className={styles.page}>
       <Header />

--- a/src/pages/ForgetPassword/ForgetPassword.module.css
+++ b/src/pages/ForgetPassword/ForgetPassword.module.css
@@ -4,32 +4,50 @@
   background-color: var(--color-bg-page);
 }
 
-.page__window {
+.page-window {
   width: 56.875rem;
   max-width: 100%;
   border-radius: 1rem;
   padding: 0;
   /* padding-top: 167px 221px 202px; */
   background-color: var(--main-white);
-  display: flex;
-  justify-content: center;
-  align-items: center;
 }
 
-.page__wrapper {
+.page-wrapper {
   width: 27.625rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   margin: auto;
   padding: 0;
   margin: 12rem auto;
-  /* margin-bottom: 202px; */
 }
 
-.page__title {
+.page-title {
   font-weight: 700;
   text-align: center;
 }
 
-.page__text {
+.page-link {
+  display: block;
+  text-align: center;
+  color: var(--color-orange);
+}
+
+.reset {
+  margin: 3rem auto;
+}
+.success {
+  margin: 4rem auto;
+}
+.success-icon {
+  width: 5.5rem;
+  height: 100%;
+  padding: 1.063rem 0.25rem 0.5rem 0.5rem;
+  justify-content: center;
+  margin-bottom: 3rem;
+}
+.success-text {
   text-align: center;
   font-size: 1.125rem;
   padding-bottom: 2.5rem;
@@ -47,10 +65,15 @@ label {
   margin: 0;
   margin-bottom: 0.6rem;
 }
-
-.page__customButton {
+.reset-text {
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 120%;
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+.reset-custom-button {
   margin-top: 3.5rem;
-  margin-bottom: 3rem;
   display: inline-block;
   width: 100%;
   padding: 1rem 0;
@@ -58,61 +81,4 @@ label {
   line-height: 120%;
   letter-spacing: 0rem;
   font-weight: 700;
-  text-align: center;
-}
-
-.page__link {
-  display: block;
-  text-align: center;
-  color: var(--color-orange);
-}
-
-/* if success block */
-.success {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin: 4rem auto;
-}
-
-.success__icon {
-  width: 5.5rem;
-  height: 100%;
-  padding: 1.063rem 0.25rem 0.5rem 0.5rem;
-  justify-content: center;
-  margin-bottom: 3rem;
-}
-/* .success span:nth-of-type(1) {
-  font-size: 1.375rem;
-  line-height: 21px;
-  margin: 1.1em auto;
-  font-weight: bold;
-} */
-
-.success__text {
-  font-size: 18px;
-  line-height: 120%;
-  font-weight: 400;
-  text-align: center;
-  margin-top: 4rem;
-}
-
-.forget__password,
-.resend__email {
-  display: flex;
-  flex-direction: column;
-  text-align: center;
-  color: var(--color-orange);
-  font-size: 18px;
-  font-weight: 500;
-  text-decoration: underline;
-}
-
-.resend__email {
-  margin-top: 3em;
-}
-
-.resend__email,
-.forget__password:hover {
-  color: var(--color-dark-orange);
 }

--- a/src/pages/ForgetPassword/ForgetPassword.module.css
+++ b/src/pages/ForgetPassword/ForgetPassword.module.css
@@ -34,6 +34,7 @@
   font-size: 1.125rem;
   padding-bottom: 2.5rem;
   padding-top: 3rem;
+  margin-bottom: 0;
 }
 
 label {
@@ -62,6 +63,8 @@ label {
 
 .page__link {
   display: block;
+  text-align: center;
+  color: var(--color-orange);
 }
 
 /* if success block */
@@ -69,16 +72,15 @@ label {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 64px auto;
-  padding-top: 17px;
+  margin: 4rem auto;
 }
 
 .success__icon {
-  width: 88px;
+  width: 5.5rem;
   height: 100%;
-  padding: 17px 4px 8px 8px;
+  padding: 1.063rem 0.25rem 0.5rem 0.5rem;
   justify-content: center;
-  margin-bottom: 48px;
+  margin-bottom: 3rem;
 }
 /* .success span:nth-of-type(1) {
   font-size: 1.375rem;
@@ -92,6 +94,7 @@ label {
   line-height: 120%;
   font-weight: 400;
   text-align: center;
+  margin-top: 4rem;
 }
 
 .forget__password,

--- a/src/pages/ForgetPassword/ForgetPassword.module.css
+++ b/src/pages/ForgetPassword/ForgetPassword.module.css
@@ -9,7 +9,6 @@
   max-width: 100%;
   border-radius: 1rem;
   padding: 0;
-  /* padding-top: 167px 221px 202px; */
   background-color: var(--main-white);
 }
 

--- a/src/pages/ForgetPassword/ForgetPassword.module.css
+++ b/src/pages/ForgetPassword/ForgetPassword.module.css
@@ -18,7 +18,6 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  margin: auto;
   padding: 0;
   margin: 12rem auto;
 }
@@ -38,6 +37,10 @@
   margin: 3rem auto;
 }
 .success {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
   margin: 4rem auto;
 }
 .success-icon {
@@ -45,14 +48,16 @@
   height: 100%;
   padding: 1.063rem 0.25rem 0.5rem 0.5rem;
   justify-content: center;
-  margin-bottom: 3rem;
+}
+.success-heading {
+  margin-top: 3rem;
 }
 .success-text {
-  text-align: center;
   font-size: 1.125rem;
-  padding-bottom: 2.5rem;
-  padding-top: 3rem;
-  margin-bottom: 0;
+  line-height: 120%;
+  font-weight: 400;
+  margin-top: 4rem;
+  text-align: center;
 }
 
 label {

--- a/src/pages/ForgetPassword/ForgetPassword.module.css
+++ b/src/pages/ForgetPassword/ForgetPassword.module.css
@@ -1,100 +1,96 @@
-p {
-  margin: 0px !important;
-}
-
 .page {
   max-width: 100%;
   height: 100dvh;
-  /* if we apply this the screen will not be full size as full size in height in 100dvh  */
-  /* height: 1024px; */
-  background-color: #eff0f0;
+  background-color: var(--color-bg-page);
 }
 
 .page__window {
-  width: 820px;
+  width: 56.875rem;
   max-width: 100%;
-  height: 750px; 
-  /* if we apply this the screen will not be full size as full size in height in 100dvh  */
-  /* max-width: 910px;
-  height: 840px; */
-  border-radius: 16px;
-  background-color: #ffffff;
+  border-radius: 1rem;
+  padding: 0;
+  /* padding-top: 167px 221px 202px; */
+  background-color: var(--main-white);
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
 .page__wrapper {
-  width: 442px;
-  height: 436px;
+  width: 27.625rem;
+  margin: auto;
+  padding: 0;
+  margin: 12rem auto;
+  /* margin-bottom: 202px; */
 }
 
 .page__title {
-  font-family: Roboto;
-  font-size: 32px;
   font-weight: 700;
-  line-height: 38.4px;
-  letter-spacing: -0.01em;
   text-align: center;
-  color: var(--fg-Primary, #081821);
 }
 
-.text {
+.page__text {
   text-align: center;
-  font-size: 1rem;
-  padding-bottom: 32px;
-  padding-top: 40px;
+  font-size: 1.125rem;
+  padding-bottom: 2.5rem;
+  padding-top: 3rem;
 }
 
 label {
-  font-weight: bold;
-  font-size: 16px;
-  line-height: 15px;
-  letter-spacing: -0.01em;
+  font-size: 1rem; /*16px*/
+  font-weight: 600;
+  line-height: 140%;
+  letter-spacing: 0.02rem;
+  color: var(--color-fg-light);
+  padding: 0;
+  margin: 0;
+  margin-bottom: 0.6rem;
 }
 
-.customButton {
-  margin-top: 48px !important;
-  margin-bottom: 48px !important;
-  width: 442px;
-  height: 56px;
-  background-color: #eb7005;
-  font-family: Roboto;
-  font-weight: 800;
-  font-size: 18px;
-  line-height: 25.2px;
+.page__customButton {
+  margin-top: 3.5rem;
+  margin-bottom: 3rem;
+  display: inline-block;
+  width: 100%;
+  padding: 1rem 0;
+  font-size: 1.25rem; /*20px*/
+  line-height: 120%;
+  letter-spacing: 0rem;
+  font-weight: 700;
   text-align: center;
-  color: #fcfcfc;
 }
 
-.customButton:hover,
-.customButton:active,
-.customButton:focus-visible,
-.customButton:focus {
-  color: #eb7005 !important;
+.page__link {
+  display: block;
 }
 
+/* if success block */
 .success {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 5.7em;
+  margin: 64px auto;
+  padding-top: 17px;
 }
 
-.success img {
-  width: 81.24px;
+.success__icon {
+  width: 88px;
   height: 100%;
-  flex-direction: column;
-  align-items: center;
+  padding: 17px 4px 8px 8px;
+  justify-content: center;
+  margin-bottom: 48px;
 }
-.success span:nth-of-type(1) {
+/* .success span:nth-of-type(1) {
   font-size: 1.375rem;
   line-height: 21px;
   margin: 1.1em auto;
   font-weight: bold;
-}
+} */
 
-.success span:nth-of-type(2) {
+.success__text {
+  font-size: 18px;
+  line-height: 120%;
+  font-weight: 400;
   text-align: center;
 }
 
@@ -106,13 +102,14 @@ label {
   color: var(--color-orange);
   font-size: 18px;
   font-weight: 500;
-  text-decoration: underline; 
+  text-decoration: underline;
 }
 
 .resend__email {
   margin-top: 3em;
 }
 
-.resend__email, .forget__password:hover {
+.resend__email,
+.forget__password:hover {
   color: var(--color-dark-orange);
 }

--- a/src/styles/globalStyles.css
+++ b/src/styles/globalStyles.css
@@ -3,42 +3,50 @@
 
 :root {
   --main-black: #000000;
-  --main-white: #FFFFFF;
+  --main-white: #ffffff;
   --main-grey: #999999;
-  --main-sand: #F7F5EC;
+  --main-sand: #f7f5ec;
   --main-mistral: #878fab;
-  --main-cyan: #01ADB4;
-  --main-blue: #64CAC7;
-  --main-lightBlue: #BFEBEC;
-  --main-green: #5BA056;
-  --main-orange: #F08324;
-  --main-red: #F05153;
-  --main-yellow: #F4DD61;
+  --main-cyan: #01adb4;
+  --main-blue: #64cac7;
+  --main-lightBlue: #bfebec;
+  --main-green: #5ba056;
+  --main-orange: #f08324;
+  --main-red: #f05153;
+  --main-yellow: #f4dd61;
 
   /* used in authentication flow */
-  --color-text-icon-default: #596B73;
-  --color-text-icon-accent: #3B494F;
-  --color-bg-light: #FCFCFC;
-  --color-border-default: #9EAFB7;
+  --color-text-icon-default: #596b73;
+  --color-text-icon-accent: #3b494f;
+  --color-bg-light: #fcfcfc;
+  --color-border-default: #9eafb7;
   --color-fg-primary: #081821;
-  --color-blurred-orange: #F6BD8F;
-  --color-orange: #DB5C00;
-  --color-accent-orange: #EB7005;
-  --color-dark-orange: #C24400;
+  --color-blurred-orange: #f6bd8f;
+  --color-orange: #db5c00;
+  --color-accent-orange: #eb7005;
+  --color-dark-orange: #c24400;
   --color-gray-dark: #454848;
-  --color-bg-page: #EFF0F0;
-}
+  --color-bg-page: #eff0f0;
+  --color-fg-light: #1d1f20;
 
-* {
-  margin: 0;
-  padding: 0;
+  font-size: 16px;
+  line-height: 140%;
+  letter-spacing: 0rem;
+  color: var(--color-fg-light);
   font-family: Roboto, sans-serif;
   font-style: normal;
   font-synthesis: none;
 }
 
+* {
+  margin: 0;
+  padding: 0;
+
+  box-sizing: border-box;
+}
+
 .content-layout {
-  max-width: 1280px;
+  max-width: 80rem;
   margin: auto;
 }
 
@@ -61,8 +69,8 @@
 .primary-btn {
   color: var(--main-black);
   background-color: var(--main-orange);
-  border: 3px solid var(--main-orange) !important;
-  border-radius: 7px;
+  border: 0.188rem solid var(--main-orange) !important;
+  border-radius: 0.438rem;
   font-weight: 500;
 }
 
@@ -70,7 +78,7 @@
 .primary-btn:hover,
 .primary-btn:focus {
   background-color: var(--main-white) !important;
-  color: var(--main-black)
+  color: var(--main-black);
 }
 
 .primary-btn:disabled {
@@ -82,13 +90,13 @@
 .secondary-btn {
   background-color: var(--main-sand);
   color: var(--main-black);
-  border: 3px solid var(--main-orange) !important;
+  border: 0.188rem solid var(--main-orange) !important;
 }
 
 .secondary-btn:hover {
-    background-color: var(--main-white);
-    color: var(--main-black);
-    border: 3px solid var(--main-orange);
+  background-color: var(--main-white);
+  color: var(--main-black);
+  border: 0.188rem solid var(--main-orange);
 }
 
 .secondary-btn:disabled {
@@ -98,8 +106,8 @@
 }
 
 .tertiary-btn {
-  font-size: 14px;
-  line-height: 21px;
+  font-size: 0.875rem;
+  line-height: 1.313rem;
   background-color: var(--main-white) !important;
   color: var(--main-black) !important;
 }
@@ -107,4 +115,56 @@
 /* Hide icons until fonts are loaded */
 .fonts-loading .material-symbols-rounded {
   visibility: hidden;
+}
+
+/* Headers Each header has different font-weight 900(black), 700(bold), 500(medium)*/
+
+h1 {
+  font-size: 2.5rem; /*40px*/
+  line-height: 120%;
+  letter-spacing: -0.05rem; /*2% from 40px = 0.8px=0.05rem*/
+  color: var(--color-fg-light);
+  padding: 0;
+  margin: 0;
+}
+h2 {
+  font-size: 2rem; /*32px*/
+  line-height: 120%;
+  letter-spacing: -0.02rem; /*1% from 32px = 0.32px=0.02rem*/
+  color: var(--color-fg-light);
+  padding: 0;
+  margin: 0;
+}
+h3 {
+  font-size: 1.5rem; /*24px*/
+  line-height: 120%;
+  letter-spacing: 0rem;
+  color: var(--color-fg-light);
+  padding: 0;
+  margin: 0;
+}
+h4 {
+  font-size: 1.25rem; /*20px*/
+  line-height: 120%;
+  letter-spacing: 0rem;
+  color: var(--color-fg-light);
+  padding: 0;
+  margin: 0;
+}
+h5 {
+  font-size: 1rem; /*16px*/
+  line-height: 140%;
+  letter-spacing: 0rem;
+  color: var(--color-fg-light);
+  padding: 0;
+  margin: 0;
+}
+
+/* Links */
+a {
+  font-size: 1.125rem; /*18px*/
+  font-weight: 500;
+  line-height: 140%;
+  letter-spacing: 0rem;
+  color: var(--color-accent-orange);
 }


### PR DESCRIPTION
## Edit forgot password page style (37)


## Requirements
- Adjust forget password to match the design in Figma.
- Follow the best practices while accomplishing the task.

## Notes
- added font-size on root in global styles, so I used rem in sizes for all elements in css.
- added sizes for headings in global styles based on figma. 
- this page has different size of container and margins on top and bottom than other pages. I adjusted the sizes based on other pages because this component with conditional rendering, and changes for 1 page will affect other pages (see screenshots below)
<img width="962" alt="2024-07-16" src="https://github.com/user-attachments/assets/70b94f12-f492-4706-81ff-31081d2a91c7">
<img width="962" alt="2024-07-16 (1)" src="https://github.com/user-attachments/assets/dd4bdd33-9b7d-455d-8631-4c78d996c14b">


## UI/UX Outcome
- now
![Screenshot 2024-07-17 150242](https://github.com/user-attachments/assets/e2d9a39c-6f30-47a1-a0b5-f3184e7b387c)

## Checklist
- [x] Pull Request title includes the issue number and a brief description of the change.
- [x] All changes should be tested and verified to work correctly.
- [x] Code follows frontend best practices.
- [x] Branch names follow the conventions in the contributing file.
- [x] Commit messages follow the naming conventions in the contributing file.