### PR TITLE
Hotfix: label class in forget password 

### DIFF
--- a/src/pages/ForgetPassword/ForgetPassword.jsx
+++ b/src/pages/ForgetPassword/ForgetPassword.jsx
@@ -83,6 +83,7 @@ export default function ForgetPassword() {
                         value={email}
                         required
                         label="Email"
+                        labelClassName={styles['custom-label']}
                         className={styles['reset-input']}
                       />
                       <CustomButton

--- a/src/pages/ForgetPassword/ForgetPassword.module.css
+++ b/src/pages/ForgetPassword/ForgetPassword.module.css
@@ -35,6 +35,7 @@
 .reset {
   margin: 3rem auto;
 }
+
 .success {
   display: flex;
   flex-direction: column;
@@ -42,15 +43,18 @@
   align-items: center;
   margin: 4rem auto;
 }
+
 .success-icon {
   width: 5.5rem;
   height: 100%;
   padding: 1.063rem 0.25rem 0.5rem 0.5rem;
   justify-content: center;
 }
+
 .success-heading {
   margin-top: 3rem;
 }
+
 .success-text {
   font-size: 1.125rem;
   line-height: 120%;
@@ -59,7 +63,7 @@
   text-align: center;
 }
 
-label {
+.custom-label {
   font-size: 1rem; /*16px*/
   font-weight: 600;
   line-height: 140%;
@@ -69,6 +73,7 @@ label {
   margin: 0;
   margin-bottom: 0.6rem;
 }
+
 .reset-text {
   font-size: 1.125rem;
   font-weight: 400;
@@ -76,6 +81,7 @@ label {
   text-align: center;
   margin-bottom: 2.5rem;
 }
+
 .reset-custom-button {
   margin-top: 3.5rem;
   display: inline-block;


### PR DESCRIPTION
##  Label styling - fix global access 

## Requirements
- Fix to be make it local so that it doesn't influence other labels

## Test step
Remember me should be in place and Email label in Forget password should still be bold and preserve its styling 

## UI/UX Outcome
<img width="1685" alt="Screenshot 2024-07-19 at 22 31 05" src="https://github.com/user-attachments/assets/b4e2a766-40a6-4fa8-ab90-f04954de1dea">
<img width="1699" alt="Screenshot 2024-07-19 at 22 32 32" src="https://github.com/user-attachments/assets/a3fef869-2fd7-4b45-850e-5d09c3d3d3ab">


## Checklist
- [x] Pull Request title includes the issue number and a brief description of the change.
- [x] All changes should be tested and verified to work correctly.
- [x] Code follows frontend best practices.
- [x] Branch names follow the conventions in the contributing file.
- [x] Commit messages follow the naming conventions in the contributing file.