### PR TITLE
Hotfix/82/logo ovelap home

### DIFF
--- a/src/components/Dashboard/Sidebar/Sidebar.module.css
+++ b/src/components/Dashboard/Sidebar/Sidebar.module.css
@@ -29,6 +29,7 @@
   justify-content: space-between;
   width: 100%;
   height: 100%;
+  margin-top:40px;
 }
 
 .otherItemsContainer,
@@ -36,7 +37,6 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  margin-top: 5px;
 }
 
 .nav {

--- a/src/components/Dashboard/Sidebar/Sidebar.module.css
+++ b/src/components/Dashboard/Sidebar/Sidebar.module.css
@@ -36,6 +36,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  margin-top: 5px;
 }
 
 .nav {

--- a/src/components/Dashboard/Sidebar/Sidebar.module.css
+++ b/src/components/Dashboard/Sidebar/Sidebar.module.css
@@ -29,7 +29,7 @@
   justify-content: space-between;
   width: 100%;
   height: 100%;
-  margin-top:40px;
+  margin-top: 40px;
 }
 
 .otherItemsContainer,


### PR DESCRIPTION
One Line Description
Fixes the overlapping issue of the Kids Logo when hovering over the Home section.

Test Steps

Hover over the Home section and verify the Kids Logo remains properly aligned without overlapping any UI elements.

UI/UX Outcome

Before: The Kids Logo overlaps with other elements when hovering over the Home section.

<img width="251" alt="image" src="https://github.com/user-attachments/assets/6f1a1fac-896f-4c6b-9b24-74ba367460ea">



After: The Kids Logo remains properly positioned and does not interfere with other elements.
<img width="254" alt="image" src="https://github.com/user-attachments/assets/2c79e5c9-be24-443a-a4d8-513dddff4c06">



Checklist

- [x]  Pull Request title includes the issue number and a brief description of the change.
- [x]  All changes have been tested and verified to work correctly.
- [x]  Code follows frontend best practices.
- [x]  Branch names follow the conventions in the contributing file.
- [x]  Commit messages follow the naming conventions in the contributing file.