### PR TITLE
Feature/85/password reset minorfix

### DIFF
--- a/src/components/shared/NotificationPage/NotificationPage.module.css
+++ b/src/components/shared/NotificationPage/NotificationPage.module.css
@@ -1,5 +1,5 @@
 .page {
-  max-width: 100%;
+  max-width: 100% !important;
   height: 110dvh;
   background-color: var(--color-bg-page);
   display: flex;
@@ -7,7 +7,7 @@
 }
 
 .page-window {
-  width: 56.875rem;
+  width: 56.875rem !important;
   height: 52.5rem;
   border-radius: 1rem;
   padding: 0;
@@ -20,7 +20,7 @@
 }
 
 .page-wrapper {
-  width: 29.25rem;
+  width: 29.25rem !important;
   height: 28.063rem;
   padding: 0;
   display: flex;

--- a/src/components/shared/ui/Button/CustomButton.jsx
+++ b/src/components/shared/ui/Button/CustomButton.jsx
@@ -1,3 +1,21 @@
+/* 
+This is a reusable button to standardize button styling. 
+Please refer to Figma for visual reference: https://www.figma.com/design/qUBlZE5TIgpqShKTVcSvRo/Kids-First-WITT(Desktop)?node-id=10101-45063&t=qkg15eX9vNqI63nz-4
+
+Below is an example of usage:
+
+        <CustomButton
+          styles={`med primary-light ${styles.customButton}`}
+          iconLeft='@media/icons/home.svg'
+          iconRight='@media/icons/home.svg'
+          type='submit'>
+          Text for button
+        </CustomButton>
+
+The styles prop accepts the predefined styles based on the classNames described in buttonStyles.css and buttonSizes.css.
+You can also add icons using the iconLeft or iconRight props to add icons to either side of the button Text.
+*/
+
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';

--- a/src/pages/ForgetPassword/ForgetPassword.jsx
+++ b/src/pages/ForgetPassword/ForgetPassword.jsx
@@ -27,6 +27,7 @@ export default function ForgetPassword() {
     e.preventDefault();
     setSuccess(false);
     setErrMsg('');
+
     try {
       const res = await forgetPassword(email);
       if (res.status === 200) {
@@ -68,7 +69,7 @@ export default function ForgetPassword() {
               </section>
             )}
             {!success && !sentEmail && (
-              <Form onSubmit={handleForgotPassword} novalidate>
+              <Form onSubmit={handleForgotPassword} noValidate>
                 <section className={styles.reset}>
                   <p className={styles['reset-text']}>
                     Please enter your account email address and we will send

--- a/src/pages/ForgetPassword/ForgetPassword.jsx
+++ b/src/pages/ForgetPassword/ForgetPassword.jsx
@@ -1,10 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
-import { Container, Form, Row, Col } from 'react-bootstrap';
+import { Container, Form } from 'react-bootstrap';
 import { NavLink } from 'react-router-dom';
 
 import { forgetPassword } from '@api';
 
-import MessageBar from '@components/MessageBar';
 import Header from '@components/shared/Header';
 import { CustomButton } from '@components/shared/ui/Button/CustomButton';
 import FormEmailInput from '@components/shared/ui/form/FormEmailInput';
@@ -40,7 +39,9 @@ export default function ForgetPassword() {
     } catch (err) {
       //eslint-disable-next-line
       console.error(err);
-      setErrMsg('There was an error with the request, please try again later.');
+      if (err.response.status === 404) {
+        setErrMsg('This email is not registered with us.');
+      }
     }
   };
 
@@ -48,61 +49,54 @@ export default function ForgetPassword() {
     <Container className={styles.page}>
       <Header />
       <Container className={styles['page-window']}>
-        <div>
-          <Row>
-            <Col className="d-flex px-0 justify-content-center align-items-center">
-              <div>
-                <Form
-                  className={`content-layout ${styles['page-wrapper']}`}
-                  onSubmit={handleForgotPassword}>
-                  <></>
-                  <h2 className={styles['page-title']}>Forgot Password</h2>
-                  {success && sentEmail ? (
-                    <section className={styles.success}>
-                      <img className={styles['success-icon']} src={logoEmailSent} alt="email-sent-icon" />
-                      <h3 className={styles['success-heading']}>Check you email</h3>
+        <Container className={`${styles['page-wrapper']}`}>
+          <div>
+            <h2 className={styles['page-title']}>Forgot Password</h2>
+            { (success && sentEmail) && (
+              <section className={styles.success}>
+                <img
+                  className={styles['success-icon']}
+                  src={logoEmailSent}
+                  alt='email-sent-icon'
+                />
+                <h3 className={styles['success-heading']}>Check you email</h3>
 
-                      <span className={styles['success-text']}>
-                        A link to reset your password has been sent to{' '}
-                        <strong>{emailDisplay.current}</strong>
-                      </span>
-                    </section>
-
-                  ) : !success && errMsg ? (
-                    <MessageBar variant="error">{errMsg}</MessageBar>
-                  ) : null}
-
-                  {success && sentEmail ? null : (
-                    <section className={styles.reset}>
-                      <p className={styles['reset-text']}>
-                        Please enter your account email address and we will send instructions to
-                        reset your password.
-                      </p>
-                      <FormEmailInput
-                        onChange={(e) => setEmail(e.target.value)}
-                        value={email}
-                        required
-                        label="Email"
-                        labelClassName={styles['custom-label']}
-                        className={styles['reset-input']}
-                      />
-                      <CustomButton
-                        styles={`primary-light ${styles['reset-custom-button']}`}
-                        type="submit"
-                        size="lg"
-                        variant="light">
-                        Next
-                      </CustomButton>
-                    </section>
-                  )}
-                  <NavLink to="/signin" className={styles['page-link']}>
-                    Back to Log in
-                  </NavLink>
-                </Form>
-              </div>
-            </Col>
-          </Row>
-        </div>
+                <span className={styles['success-text']}>
+                  A link to reset your password has been sent to{' '}
+                  <strong>{emailDisplay.current}</strong>
+                </span>
+              </section>
+            )}
+            {!success && !sentEmail && (
+              <Form onSubmit={handleForgotPassword} novalidate>
+                <section className={styles.reset}>
+                  <p className={styles['reset-text']}>
+                    Please enter your account email address and we will send
+                    instructions to reset your password.
+                  </p>
+                  <FormEmailInput
+                    onChange={(e) => setEmail(e.target.value)}
+                    value={email}
+                    required
+                    label='Email'
+                    labelClassName={styles['custom-label']}
+                    className={styles['reset-input']}
+                    errorMessage={errMsg}
+                  />
+                  <CustomButton
+                    styles={`primary-light ${styles['reset-custom-button']}`}
+                    type='submit'
+                  >
+                    Next
+                  </CustomButton>
+                </section>
+              </Form>
+            )}
+            <NavLink to='/signin' className={styles['page-link']}>
+              Back to Log in
+            </NavLink>
+          </div>
+        </Container>
       </Container>
     </Container>
   );

--- a/src/pages/ForgetPassword/ForgetPassword.module.css
+++ b/src/pages/ForgetPassword/ForgetPassword.module.css
@@ -1,24 +1,29 @@
 .page {
-  max-width: 100%;
+  max-width: 100% !important;
   height: 110dvh;
   background-color: var(--color-bg-page);
+  display: flex;
+  flex-direction: column;
 }
 
 .page-window {
-  width: 56.875rem;
-  max-width: 100%;
+  width: 56.875rem !important;
+  height: 52.5rem;
   border-radius: 1rem;
   padding: 0;
   background-color: var(--main-white);
+  align-self: center;
+  display: flex;
+  flex-direction: column;
 }
 
 .page-wrapper {
-  width: 27.625rem;
+  width: 27.625rem !important;
+  margin: auto 14.625rem !important; 
+  padding: 0;
+  align-self: center;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  padding: 0;
-  margin: 12rem auto;
 }
 
 .page-title {

--- a/src/pages/ResetPassword/ResetPassword.jsx
+++ b/src/pages/ResetPassword/ResetPassword.jsx
@@ -4,9 +4,11 @@ import { NavLink, useNavigate, useParams } from 'react-router-dom';
 
 import { resetPassword, resetPasswordLink } from '@api';
 import Header from '@components/shared/Header';
+import NotificationPage from '@components/shared/NotificationPage';
 import { CustomButton } from '@components/shared/ui/Button/CustomButton';
 import FormPasswordInput from '@components/shared/ui/form/FormPasswordInput';
 
+import emailImage from '@media/icons/email-image.svg';
 import { validatePassword } from '@utils/validationUtils';
 
 import styles from './ResetPassword.module.css';
@@ -22,6 +24,7 @@ export default function ResetPassword() {
   const [successMessage, setSuccessMessage] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [showTextPaswsord, setShowTextPassword] = useState('');
+  const [linkExpired, setLinkExpired] = useState(false);
   const [allPasswordErrorsChecked, setAllPasswordErrorsChecked] =
     useState(false);
   const navigate = useNavigate();
@@ -36,7 +39,7 @@ export default function ResetPassword() {
     } catch (err) {
       //eslint-disable-next-line no-console
       console.error(err);
-      // TODO: Proper error handling in case Token/Email verification fails
+      setLinkExpired(true);
     }
   };
 
@@ -95,14 +98,24 @@ export default function ResetPassword() {
           setErrorMessage(err.response.data.message);
         } else {
           console.error(err);
-          // TODO: Proper error handling in case of other types of failures
+          setLinkExpired(true);
         }
       }
     },
     [email, password, resetPasswordToken]
   );
 
-  return (
+  return linkExpired ? (
+    <NotificationPage
+      title='Link Expired'
+      image={emailImage}
+      altText='link-expired-icon'
+      message='This password reset link is no longer valid'
+      description='Please request a new password reset link to continue.'
+      linkText='Back to Forgot Password'
+      linkTo='/forgot-password'
+    />
+  ) : (
     <Container className={styles.page}>
       <Header />
       <Container className={styles['page-window']}>


### PR DESCRIPTION
# Feature/85/password reset minorfix

## One Line Description
Fix error styling on forgot password page and add expired link warning for reset password page.

## Requirements
1. Errors were displaying in a red box on the Forgot Password page which did not match figma design.
2. No warning was shown when reset password failed due to token expiry.

## Test Steps
1. Go to Login and click on 'Forgot your password?' link
2. Enter an invalid email address or non-registered email address. The warning should appear under the email input instead of in a red box on top of the input.
3. Enter a valid email address and click Next. 
4. In your mail box, click to Reset Your Password. 
5. In the Password Reset page, set your new password and this should navigate to a confirmation page.
6. Go back to the previous page, you should see a Link Expired notification.
7. Click on the Reset Your Password link in your mailbox, it should also open a new tab with the Link Expired notification.

## UI/UX Outcome
Forgot password error:
![image](https://github.com/user-attachments/assets/475ffcb0-68b1-420e-b902-99169fad71bf)

Expired Link notification:
![image](https://github.com/user-attachments/assets/18cb9287-c815-4291-95d8-e2e689a39d84)
