### PR TITLE
add trim to remove spaces for name and otherNotes

### DIFF
--- a/src/components/KidsInfo/KidForm.module.css
+++ b/src/components/KidsInfo/KidForm.module.css
@@ -63,7 +63,7 @@
   height: 20px;
   border: 2px solid rgba(246, 188, 140, 1);
   border-radius: 4px;
-  background-color: #fff;
+  background-color: rgba(252, 252, 252, 1);
   position: relative;
 }
 

--- a/src/components/KidsInfo/KidForm.module.css
+++ b/src/components/KidsInfo/KidForm.module.css
@@ -20,7 +20,7 @@
   position: relative;
   top: 50px;
   left: 160px;
-  border: 4px white solid;
+  border: 4px rgba(252, 252, 252, 1) solid;
   background: rgba(207, 182, 239, 1);
   border-radius: 50%;
   padding: 10px;

--- a/src/components/KidsInfo/constants/interests.js
+++ b/src/components/KidsInfo/constants/interests.js
@@ -4,16 +4,16 @@ export const INTEREST_VALUE = [
     label: 'Animals',
   },
   {
-    value: 'Arts and Crafts',
-    label: 'Arts and Crafts',
+    value: 'Arts and crafts',
+    label: 'Arts and crafts',
   },
   {
     value: 'Basketball',
     label: 'Basketball',
   },
   {
-    value: 'Board Games',
-    label: 'Board Games',
+    value: 'Board games',
+    label: 'Board games',
   },
   {
     value: 'Cooking',
@@ -28,8 +28,8 @@ export const INTEREST_VALUE = [
     label: 'Drawing',
   },
   {
-    value: 'Ice Hockey',
-    label: 'Ice Hockey',
+    value: 'Ice hockey',
+    label: 'Ice hockey',
   },
   {
     value: 'Music',

--- a/src/components/KidsInfo/kidValidateSchema.js
+++ b/src/components/KidsInfo/kidValidateSchema.js
@@ -10,6 +10,7 @@ export const kidValidateSchema = Yup.object().shape({
     (value) => !value || (value && SUPPORTED_FORMATS.includes(value.type))
   ),
   name: Yup.string()
+    .trim()
     .min(2, 'Accepts a minimum of 2 characters')
     .max(40, 'Reached maximum characters')
     .matches(
@@ -38,9 +39,10 @@ export const kidValidateSchema = Yup.object().shape({
       }
     ),
   otherNotes: Yup.string()
+    .trim()
     .max(200, 'Reached maximum characters')
     .matches(
-      /^[a-zA-Z0-9\s.,'-]+$/,
+      /^[a-zA-Z0-9\s.,'-]*$/,
       'Accepts only English letters, numbers, and special characters [.],[,],[\'],[-]'
     ),
 });


### PR DESCRIPTION
## One Line Description
added` trim() `for name and otherNotes to remove spaces 
Fixed enums with two-word interests, changing them from upper case to lower case according to GitBook guidelines.


## UI/UX Outcome
![Screen Shot 2024-08-18 at 10 43 09 PM](https://github.com/user-attachments/assets/500c10f6-2b6b-4e74-90af-ed0a99fdb7e2)
![Screen Shot 2024-08-18 at 10 43 39 PM](https://github.com/user-attachments/assets/6fa676cd-306c-469b-99f4-b95aa85be49b)

## Checklist
- [x] Pull Request title includes the issue number and a brief description of the change.
- [x] All changes should be tested and verified to work correctly.
- [x] Code follows frontend best practices.
- [x] Branch names follow the conventions in the contributing file.
- [x] Commit messages follow the naming conventions in the contributing file.