### PR TITLE
#92 Forgot Password page: Added email validation prior to form submit

### DIFF
--- a/src/pages/ForgetPassword/ForgetPassword.jsx
+++ b/src/pages/ForgetPassword/ForgetPassword.jsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 import { Container, Form } from 'react-bootstrap';
 import { NavLink } from 'react-router-dom';
 
+import { object, string } from 'yup';
+
 import { forgetPassword } from '@api';
 
 import Header from '@components/shared/Header';
@@ -19,8 +21,19 @@ export default function ForgetPassword() {
   const [success, setSuccess] = useState(false);
   const [sentEmail, setSentEmail] = useState(false);
 
+  let formSchema = object({
+    email: string().email(),
+  });
+
   useEffect(() => {
     emailDisplay.current = email;
+    formSchema
+      .validate({ email })
+      .then(() => setErrMsg(''))
+      .catch((err) => {
+        console.log(err);
+        setErrMsg('Please enter a valid email address');
+      });
   }, [email]);
 
   const handleForgotPassword = async (e) => {
@@ -40,9 +53,7 @@ export default function ForgetPassword() {
     } catch (err) {
       //eslint-disable-next-line
       console.error(err);
-      if (err.response.status === 404) {
-        setErrMsg('This email is not registered with us.');
-      }
+      setErrMsg('This email is not registered with us');
     }
   };
 
@@ -53,7 +64,7 @@ export default function ForgetPassword() {
         <Container className={`${styles['page-wrapper']}`}>
           <div>
             <h2 className={styles['page-title']}>Forgot Password</h2>
-            { (success && sentEmail) && (
+            {success && sentEmail && (
               <section className={styles.success}>
                 <img
                   className={styles['success-icon']}


### PR DESCRIPTION
## One Line Description
Added email validation prior to form submit on forgot password page

## Requirements
As the user types their email address, an error message will display, stating "Please enter a valid email address," until they fully enter their email in the correct format. According to  figma: https://www.figma.com/design/qUBlZE5TIgpqShKTVcSvRo/Kids-First-WITT(Desktop)?node-id=12825-49985&t=H4KoijWKvsebEPAp-4 

## Test Steps
On http://localhost:3000/forgot-password start typing email. There should be a warning to "Please enter a valid email address" until a valid email address is entered.

## UI/UX Outcome
https://github.com/user-attachments/assets/4cf75bc9-855c-4b45-86a5-91f54278d368