### PR TITLE
fix(saved kids profiles) : update share and edit button styles to mat…

### DIFF
--- a/src/components/Dashboard/Kids/Kids.jsx
+++ b/src/components/Dashboard/Kids/Kids.jsx
@@ -17,11 +17,11 @@ const Kids = () => {
   const [fetchKidsCount, setFetchKidsCount] = useState(0);
   const [kidsProfiles, setKidsProfiles] = useState();
   const colors = {
-    yellow: '#FFE08C',
-    red: '#FDA4A6',
-    purple: '#CFB6EF',
-    blue: '#A4D1F1',
-    green: '#ADE4DA',
+    yellow: '#FFD66633',
+    red: '#FF6B6D33',
+    purple: '#C29EEF33',
+    blue: '#8CC7F133',
+    green: '#85E4D133',
   };
 
   useEffect(() => {

--- a/src/components/Dashboard/Kids/KidsSavedProfile/SavedKidProfile.module.css
+++ b/src/components/Dashboard/Kids/KidsSavedProfile/SavedKidProfile.module.css
@@ -78,20 +78,19 @@
 }
 
 .action-icon {
-  width: 20px;
-  height: 20px;
+  width: 22px;
+  height: 22px;
   margin-right: 8px;
 }
 
 .action-text {
   font-weight: 700;
-  min-width: 69px;
   width: auto;
   height: 24px;
   padding: 0px 8px;
   gap: 8px;
   line-height: 24px;
-  font-size: 24px;
+  font-size: var(--fontsizeL);
 }
 
 .info-list {


### PR DESCRIPTION
## One Line Description
review CSS for kids saved profiles

## Requirements
- Adjust the font weight of the Share and Edit buttons to match the Figma design.
- Increase the size of the Share and Edit button icons to match the Figma design.
- Lighten the profile colors to align with the color scheme in the Figma design.

## Test Steps
1. Open the application.
2. Navigate to the sidebar and click on kids info and create a kid profile
3. Compare the font weight, icon size and background color of the profiles with the Figma design. 

##Actual UI/UX Outcome 
![3 saved kids profile pics](https://github.com/user-attachments/assets/25b9dacd-5ae8-4450-ae05-440a80ac5f25)

## Expected UI/UX Outcome
- https://www.figma.com/design/qUBlZE5TIgpqShKTVcSvRo/Kids-First-WITT(Desktop)?node-id=13353-54892&node-type=frame&t=EtaYPtMAwmBEMZDO-0

## Checklist
- [ ] Pull Request title includes the issue number and a brief description of the change.
- [ ] All changes should be tested and verified to work correctly.
- [ ] Code follows frontend best practices.
- [ ] Branch names follow the conventions in the contributing file.
- [ ] Commit messages follow the naming conventions in the contributing file.